### PR TITLE
add media capabilities

### DIFF
--- a/client/.env.template
+++ b/client/.env.template
@@ -1,0 +1,1 @@
+GATSBY_API_URL=http://localhost:8080

--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,8 @@
     "socket.io-client": "^2.2.0",
     "twitter-text": "^3.0.0",
     "typeface-lato": "^0.0.75",
-    "urql": "^1.5.0"
+    "urql": "^1.5.0",
+    "use-local-slice": "^1.1.1"
   },
   "devDependencies": {
     "dotenv": "^8.1.0",

--- a/client/src/components/Card.js
+++ b/client/src/components/Card.js
@@ -9,6 +9,8 @@ import { getStatusColor } from "../utils/helpers"
 function Card({ scheduledTweet }) {
   const statusColor = getStatusColor(scheduledTweet.status)
 
+  const mediaSum = scheduledTweet.tweets.reduce((acc, tweet) => acc + tweet.media.length, 0)
+
   return (
     <Box
       bg="white"
@@ -39,6 +41,10 @@ function Card({ scheduledTweet }) {
           </>
         )}
       </Text>
+
+      {mediaSum > 0 && (
+        <Badge as="span">{`${mediaSum} media attachment${mediaSum > 1 ? "s" : ""}`} </Badge>
+      )}
 
       {scheduledTweet.status !== STATUS.posted && (
         <>

--- a/client/src/components/MediaInput.js
+++ b/client/src/components/MediaInput.js
@@ -1,0 +1,31 @@
+import React from "react"
+
+import { Grid, Textarea, Input, Select } from "@chakra-ui/core"
+export function MediaInput({ media: { id, type, externalUrl, altText }, onUpdate }) {
+  return (
+    <Grid my={0} templateColumns="auto 150px" gap={8}>
+      <Grid my={0} templateColumns="10ch auto" rowGap={2}>
+        <span htmlFor={`#${id}-type`}>Type:</span>
+        <Select id={`#${id}-type`} value={type} isDisabled>
+          <option value={type}>{type}</option>
+        </Select>
+
+        <label htmlFor={`#${id}-externalUrl`}>Url:</label>
+        <Input
+          id={`#${id}-externalUrl`}
+          value={externalUrl}
+          onChange={e => onUpdate({ externalUrl: e.target.value })}
+        />
+        <label htmlFor={`#${id}-altText`}>Alt:</label>
+        <Textarea
+          id={`#${id}-altText`}
+          value={altText}
+          onChange={e => onUpdate({ altText: e.target.value })}
+        />
+      </Grid>
+      <a href={externalUrl} target="_blank" rel="noopener noreferrer">
+        <img src={externalUrl || "http://"} style={{ width: "100%", height: "100%" }} />
+      </a>
+    </Grid>
+  )
+}

--- a/client/src/components/TweetInput.js
+++ b/client/src/components/TweetInput.js
@@ -1,13 +1,14 @@
 import React from "react"
 import TweetParser from "twitter-text"
-import { Flex, Grid, IconButton, Textarea } from "@chakra-ui/core"
+import { Flex, Grid, IconButton, Textarea, Button } from "@chakra-ui/core"
 import { COLORS } from "../utils/constants"
+import { MediaInput } from "./MediaInput"
 
-function TweetInput({ tweet, onChange, removeTweet }) {
+function TweetInput({ tweet, onChange, removeTweet, onAddMedia, onRemoveMedia, onUpdateMedia }) {
   const { valid } = TweetParser.parseTweet(tweet.content)
 
   return (
-    <Grid my={8} templateColumns="auto 50px">
+    <Grid my={8} templateColumns="auto 50px" gap={4}>
       <Textarea
         placeholder="Tweet..."
         value={tweet.content}
@@ -27,6 +28,35 @@ function TweetInput({ tweet, onChange, removeTweet }) {
           onClick={removeTweet}
         />
       </Flex>
+
+      {tweet.media.map((media, mediaIndex) => (
+        <React.Fragment key={media.id}>
+          <MediaInput media={media} onUpdate={data => onUpdateMedia({ mediaIndex, ...data })} />
+          <Flex align="center" justify="center">
+            <IconButton
+              aria-label="Remove media"
+              icon="delete"
+              variant="ghost"
+              variantColor={COLORS.danger}
+              size="sm"
+              onClick={() => onRemoveMedia({ mediaIndex })}
+            />
+          </Flex>
+        </React.Fragment>
+      ))}
+      <div>
+        <Button
+          leftIcon="add"
+          variant="outline"
+          variantColor={COLORS.primary}
+          size="sm"
+          mb={8}
+          display="flex"
+          onClick={onAddMedia}
+        >
+          add Media
+        </Button>
+      </div>
     </Grid>
   )
 }

--- a/client/src/components/TweetPage.js
+++ b/client/src/components/TweetPage.js
@@ -288,7 +288,7 @@ function useScheduledTweet() {
       ) {
         scheduledTweet.tweets[tweetIndex].media.push({
           id: shortId.generate(),
-          type: "externalImage",
+          type: "TWEET_IMAGE_EXTERNAL",
           externalUrl: "",
           altText: "",
         })

--- a/client/src/pages/dashboard.js
+++ b/client/src/pages/dashboard.js
@@ -21,6 +21,12 @@ const dashboardViewQuery = gql`
         tweets {
           id
           content
+          media {
+            id
+            type
+            externalUrl
+            altText
+          }
         }
       }
     }

--- a/database/.env.template
+++ b/database/.env.template
@@ -1,0 +1,1 @@
+NODE_ENV=development

--- a/database/src/store.js
+++ b/database/src/store.js
@@ -40,9 +40,23 @@ exports.createStore = function() {
     content: Sequelize.STRING,
   })
 
+  const Media = db.define("media", {
+    id: {
+      type: Sequelize.STRING,
+      primaryKey: true,
+    },
+    type: Sequelize.STRING,
+    externalUrl: Sequelize.STRING,
+    altText: Sequelize.STRING,
+  })
+
   User.hasMany(ScheduledTweet)
   ScheduledTweet.belongsTo(User)
   ScheduledTweet.hasMany(Tweet, { onDelete: "cascade" })
+  Tweet.hasMany(Media, { onDelete: "cascade" })
 
-  return { User, ScheduledTweet, Tweet }
+  // in dev: uncomment to (re)create sqlite database
+  // db.sync({ force: true })
+
+  return { User, ScheduledTweet, Tweet, Media }
 }

--- a/jobs/.env.template
+++ b/jobs/.env.template
@@ -1,0 +1,6 @@
+TWITTER_CONSUMER_KEY=<your twitter consumer key>
+TWITTER_CONSUMER_SECRET=<your twitter secret key>
+
+TOKEN_SECRET=a random string
+
+NODE_ENV=development

--- a/jobs/src/index.js
+++ b/jobs/src/index.js
@@ -2,15 +2,18 @@ import "./env"
 import Sequelize from "sequelize"
 import jwt from "jsonwebtoken"
 import request from "request-promise"
+import pureRequest from "request"
 import { createStore } from "@ts/database"
 
 const TOKEN_SECRET = process.env.TOKEN_SECRET
 const TWITTER_API = "https://api.twitter.com/1.1"
+const TWITTER_UPLOAD_API = "https://upload.twitter.com/1.1"
 
 const Op = Sequelize.Op
 
 async function twitter() {
-  const { User, ScheduledTweet, Tweet } = createStore()
+  const store = createStore()
+  const { User, ScheduledTweet, Tweet, Media } = store
 
   try {
     const time = new Date()
@@ -27,7 +30,10 @@ async function twitter() {
   async function postScheduledTweet(st) {
     const [user, tweets] = await Promise.all([
       User.findByPk(st.userId),
-      Tweet.findAll({ where: { scheduledTweetId: st.id } }),
+      Tweet.findAll({
+        where: { scheduledTweetId: st.id },
+        include: [Media],
+      }),
     ])
 
     let { token, secret } = user
@@ -38,7 +44,12 @@ async function twitter() {
     try {
       let id = null
       for (let tweet of tweets) {
-        const res = await postTweet(tweet.content, id, token, secret)
+        const media_ids = (
+          await Promise.all(tweet.media.map(media => uploadMedia(media, token, secret)))
+        )
+          .map(response => response.media_id_string)
+          .join(",")
+        const res = await postTweet(tweet.content, { id, media_ids }, token, secret)
         id = res.id_str
       }
 
@@ -49,29 +60,85 @@ async function twitter() {
     }
   }
 
-  function postTweet(status, id, token, secret) {
+  function postToTwitter(data, token, token_secret) {
     return request.post({
-      url: `${TWITTER_API}/statuses/update.json`,
       oauth: {
         consumer_key: process.env.TWITTER_CONSUMER_KEY,
         consumer_secret: process.env.TWITTER_CONSUMER_SECRET,
         token,
-        token_secret: secret,
+        token_secret,
       },
-      json: true,
-      headers: {
-        "Content-Type": "application/json",
-      },
-      form: {
-        status,
-        ...(id
-          ? {
-              in_reply_to_status_id: id,
-              auto_populate_reply_metadata: true,
-            }
-          : {}),
-      },
+      ...data,
     })
+  }
+
+  async function uploadMedia({ type, externalUrl, altText }, token, secret) {
+    if (type === "TWEET_IMAGE_EXTERNAL") {
+      const upload = await postToTwitter(
+        {
+          url: `${TWITTER_UPLOAD_API}/media/upload.json`,
+          headers: {
+            "Content-Type": "multipart/form-data",
+          },
+          json: true,
+          formData: {
+            media_category: "tweet_image",
+            media: {
+              value: pureRequest(externalUrl),
+              options: {
+                filename: "upload.png",
+                contentType: "image/png",
+              },
+            },
+          },
+        },
+        token,
+        secret,
+      )
+
+      if (altText) {
+        await postToTwitter(
+          {
+            url: `${TWITTER_UPLOAD_API}/media/metadata/create.json`,
+            headers: {
+              "Content-Type": "application/json",
+            },
+            json: true,
+            body: { media_id: upload.media_id_string, alt_text: { text: altText.slice(0, 420) } },
+          },
+          token,
+          secret,
+        )
+      }
+
+      return upload
+    } else {
+      throw new Error("unknown media type")
+    }
+  }
+
+  function postTweet(status, { id, media_ids }, token, secret) {
+    return postToTwitter(
+      {
+        url: `${TWITTER_API}/statuses/update.json`,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        json: true,
+        form: {
+          status,
+          media_ids,
+          ...(id
+            ? {
+                in_reply_to_status_id: id,
+                auto_populate_reply_metadata: true,
+              }
+            : {}),
+        },
+      },
+      token,
+      secret,
+    )
   }
 }
 

--- a/server/.env.template
+++ b/server/.env.template
@@ -1,0 +1,11 @@
+TWITTER_CONSUMER_KEY=<your twitter consumer key>
+TWITTER_CONSUMER_SECRET=<your twitter secret key>
+
+API_URL=http://localhost:8080
+
+TOKEN_SECRET=a random string
+JWT_SECRET=a random string
+
+SESSION_SECRET=a random string
+
+NODE_ENV=development

--- a/server/src/graphql/schema.js
+++ b/server/src/graphql/schema.js
@@ -41,6 +41,14 @@ const typeDefs = gql`
   type Tweet {
     id: ID!
     content: String!
+    media: [Media]!
+  }
+
+  type Media {
+    id: ID!
+    type: String!
+    externalUrl: String!
+    altText: String!
   }
 
   input ScheduledTweetInput {
@@ -53,6 +61,14 @@ const typeDefs = gql`
   input TweetInput {
     id: ID!
     content: String!
+    media: [MediaInput!]!
+  }
+
+  input MediaInput {
+    id: ID!
+    type: String!
+    externalUrl: String!
+    altText: String!
   }
 `
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6307,6 +6307,11 @@ ignore@^5.1.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
+immer@^3.1.3:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-3.3.0.tgz#ee7cf3a248d5dd2d4eedfbe7dfc1e9be8c72041d"
+  integrity sha512-vlWRjnZqoTHuEjadquVHK3GxsXe1gNoATffLEA8Qbrdd++Xb+wHEFiWtwAKTscMBoi1AsvEMXhYRzAXA8Ex9FQ==
+
 immutable@~3.7.6:
   version "3.7.6"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
@@ -11604,6 +11609,13 @@ use-dark-mode@2.3.1:
   dependencies:
     "@use-it/event-listener" "^0.1.2"
     use-persisted-state "^0.3.0"
+
+use-local-slice@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/use-local-slice/-/use-local-slice-1.1.1.tgz#cfbbb3f24d405a726964110966b5d8877338d6a7"
+  integrity sha512-fe8wEwH0wVO4m4Y+KvDZ1+HsnK3uqJOGHQTxQnzis88PLWmUnMMSkaWuM0/iRn7ZX73gw1gdawaK56ASCBGpNw==
+  dependencies:
+    immer "^3.1.3"
 
 use-memo-one@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
So I'm still working on this, but to make things as transparent as possible I'm already opening a draft PR :)

This would in the end allow for media attachments of scheduled tweets. 

As I said on twitter, I'd not add an upload but the ability to specify an external url that will be used as the source for the upload. That way you won't have to pay for storage.

Things to note: I refactored the `useScheduledTweet` hook to internally use `use-local-slice` which is a convenient wrapper around `useReducer` and `immer`, as with all the extra methods I had to add there it became quite unweildy. I hope that is okay.

My current TODO list:

* [ ] handle the correct order for multiple media attachments
* [x] add the actual upload to the job
* [ ] maybe validate the url from the frontend for existence
* [ ] somehow manage a database migration? I guess that will be up to you as I cannot see any migrations there?

If you already have any feedback, I'd love to hear it!